### PR TITLE
Add --all-versions option to backfill historical PyPI versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "httpx == 0.25.0",
     "Jinja2 == 3.1.2",
     "jsonschema == 4.19.1",
-    "pypi-simple[tqdm] == 1.2.0",
     "tomli >= 2.0,< 3.0; python_version <= '3.10'",
     "PyYAML == 6.0.1",
 ]

--- a/setup-iOS.sh
+++ b/setup-iOS.sh
@@ -118,3 +118,6 @@ echo
 echo "Build lru-dict for the ARM64 device target:"
 echo "   forge iphoneos:arm64 lru-dict"
 echo
+echo "Build all applicable versions of lru-dict for all iOS targets:"
+echo "   forge iOS --all-versions lru-dict"
+echo

--- a/src/forge/pypi.py
+++ b/src/forge/pypi.py
@@ -1,0 +1,67 @@
+import datetime
+import json
+import ssl
+import sys
+from functools import lru_cache
+from urllib.request import urlopen
+
+import certifi
+
+START_YEAR = datetime.datetime.now().year - 3
+
+
+@lru_cache
+def get_pypi_releases(package_name):
+    url = f"https://pypi.org/pypi/{package_name}/json"
+
+    # ensure we're using a root certificate that works with PyPI
+    context = ssl.create_default_context(cafile=certifi.where())
+    releases = json.load(urlopen(url, context=context))["releases"]
+
+    return releases
+
+
+def get_pypi_versions(package_name, year=START_YEAR):
+    """Return 'all versions' for the package.
+
+    This isn't really "all" versions - it's all versions:
+    * Published since `year` (last 3 years by default)
+    * for which there is a macOS wheel published
+    * for the current version of python
+
+    :param name: The PyPI name of the package to query.
+    """
+    releases = get_pypi_releases(package_name)
+
+    versions = set()
+    for version, release in releases.items():
+        for package in release:
+            if (
+                package["packagetype"] == "bdist_wheel"
+                and "-macosx_" in package["filename"]
+                and int(package["upload_time"].split("-")[0]) >= year
+                and not any(c.isalpha() for c in version)
+                and package["python_version"] == f"cp3{sys.version_info.minor}"
+            ):
+                versions.add(version)
+
+    return sorted(versions)
+
+
+@lru_cache
+def get_pypi_source_urls(package_name):
+    """Get the download source URLs for a PyPI package.
+
+    :param name: The PyPI name of the package to query.
+    :returns: a dictionary URLs for of all non-yanked source distributions for the
+        project, keyed by version number.
+    """
+    releases = get_pypi_releases(package_name)
+
+    urls = {}
+    for version, release in releases.items():
+        for package in release:
+            if package["packagetype"] == "sdist" and not package["yanked"]:
+                urls[version] = package["url"]
+
+    return urls


### PR DESCRIPTION
Adds a `--all-versions` option so that you can build *all* historical versions of a package in one pass.

Also captures and logs build failures, rather than hard crashing.

Replaces PyPISimple with direct calls on the PyPI API, because PyPISimple seems to be using the older simple API, rather than the newer JSON API. The simple API is missing a lot of useful metadata.

Fixes #8.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
