### PR TITLE
Capture logs and output to file during builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,8 @@ If you're *not* using Python-Apple-support, the setup process requires more manu
     (venv3.11) $ forge iphonesimulator:12.0:arm64 lru-dict
 
 Once this command completes, there should be a wheel for each platform in the ``dist``
-folder.
+folder. A log for each successful build will be in the ``logs`` folder; a log for each
+unsuccessful build (if there are any) will be in the ``errors`` folder.
 
 The special snowflakes
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/recipes/libjpeg/meta.yaml
+++ b/recipes/libjpeg/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://downloads.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-1.5.3.tar.gz
 
 patches:
-  - mobile.patch
+  - config.patch
 
 build:
   number: 1

--- a/src/forge/__main__.py
+++ b/src/forge/__main__.py
@@ -176,6 +176,7 @@ def main():
     else:
         build_targets = args.build_targets
 
+    successes = []
     failures = []
     for build_target in build_targets:
         if Path(build_target).is_dir():
@@ -230,24 +231,30 @@ def main():
 
             # Build the package for each required platform.
             for sdk, sdk_version, arch in build_platforms:
-                print("=" * 80)
-                print(f"Building {package} for {sdk} {sdk_version} on {arch}")
-                print("=" * 80)
                 cross_venv = CrossVEnv(sdk=sdk, sdk_version=sdk_version, arch=arch)
                 builder = package.builder(cross_venv)
-                print(f"\n[{cross_venv}] Build package")
                 success = builder.build(clean=first)
 
                 # If the build was successful, subsequent passes don't need to be clean.
                 if success:
                     first = False
+                    successes.append((package_name_or_recipe, version, cross_venv.tag))
                 else:
                     failures.append((package_name_or_recipe, version, cross_venv.tag))
 
+    if successes:
+        print()
+        print("Successful builds for:")
+        for name, version, tag in successes:
+            print(f" * {name} {version if version else '(default version)'} ({tag})")
+
     if failures:
+        print()
         print("Failed builds for:")
         for name, version, tag in failures:
-            print(f" * {name} {version} ({tag})")
+            print(f" * {name} {version if version else '(default version)'} ({tag})")
+
+    print()
 
 
 if __name__ == "__main__":

--- a/src/forge/logger.py
+++ b/src/forge/logger.py
@@ -1,0 +1,26 @@
+import traceback
+
+
+def log(log_file, *args, debug=False, **kwargs):
+    """Log output to the screen, and to the log file.
+
+    :param log_file: An open file handle to write log content to
+    :param args: The arguments to pass to print
+    :param debug: Is the output debug-specific? Debug output is only output to the log
+        file.
+    :param kwargs: Additional keyword arguments to pass to print.
+    """
+    if not debug:
+        print(*args, **kwargs)
+    if log_file:
+        print(*args, **kwargs, file=log_file)
+
+
+def log_exception(log_file):
+    """Log the current exception stack tracce to the screen, and to the log file.
+
+    :param log_file: An open file handle to write log content to
+    """
+    traceback.print_exc()
+    if log_file:
+        traceback.print_exc(file=log_file)

--- a/src/forge/subprocess.py
+++ b/src/forge/subprocess.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import shlex
+import subprocess as stdlib_subprocess
+
+from forge.logger import log
+
+# Pass through check_output without logging
+check_output = stdlib_subprocess.check_output
+CalledProcessError = stdlib_subprocess.CalledProcessError
+
+
+def run(logfile, *args, **kwargs):
+    """A wrapper around subprocess.run() that logs all output.
+
+    Subprocesses will always be run in check mode, with UTF-8 text output, and stderr
+    redirected to stdout, and stdout being piped so it can be logged.
+
+    :param logfile: An open file handle to which all output will be logged.
+    :param args: The args to pass to subprocess.run
+    :param kwargs: The keyword arguments to pass to subprocess.run.
+    """
+    # stdout/err must be piped so the output streamer can print it.
+    kwargs["stdout"] = stdlib_subprocess.PIPE
+    kwargs["stderr"] = stdlib_subprocess.STDOUT
+    # use line-buffered output by default
+    kwargs["bufsize"] = 1
+    # use text mode
+    kwargs["encoding"] = "UTF-8"
+    kwargs["text"] = True
+    kwargs["errors"] = "ignore"
+
+    log(logfile)
+    log(logfile, f">>> {shlex.join(str(arg) for arg in args[0])}", debug=True)
+    for key, value in kwargs.get("env", {}).items():
+        log(logfile, f"    {key}={shlex.quote(value)}", debug=True)
+    log(logfile, "-" * 80, debug=True)
+
+    with stdlib_subprocess.Popen(*args, **kwargs) as process:
+        while (return_code := process.poll()) is None:
+            output = process.stdout.readline()
+            if output:
+                log(logfile, output.strip())
+
+        log(logfile, "-" * 80, debug=True)
+        log(logfile, f"<<< Return code: {return_code}", debug=True)
+
+    if return_code:
+        raise stdlib_subprocess.CalledProcessError(return_code, args)
+
+    return stdlib_subprocess.CompletedProcess(args, return_code)


### PR DESCRIPTION
Any console output generated during a build is now output to a file in a logs directory. If a build fails, the log is moved to the errors directory.

Fixes #9.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
