### PR TITLE
Add recipe for Matplotlib

### DIFF
--- a/recipes/contourpy/meta.yaml
+++ b/recipes/contourpy/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: contourpy
+  version: "1.0.5"

--- a/recipes/kiwisolver/meta.yaml
+++ b/recipes/kiwisolver/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: kiwisolver
+  version: 1.3.2
+
+requirements:
+  build:
+    - cppy 1.2.1

--- a/recipes/kiwisolver/test.py
+++ b/recipes/kiwisolver/test.py
@@ -1,0 +1,21 @@
+# Based on https://kiwisolver.readthedocs.io/en/latest/basis/basic_systems.html
+def test_basic():
+    from kiwisolver import Solver, Variable
+
+    x1 = Variable("x1")
+    x2 = Variable("x2")
+    xm = Variable("xm")
+
+    constraints = [x1 >= 0, x2 <= 100, x2 >= x1 + 10, xm == (x1 + x2) / 2]
+    solver = Solver()
+    for cn in constraints:
+        solver.addConstraint(cn)
+
+    solver.addConstraint((x1 == 40) | "weak")
+    solver.addEditVariable(xm, "strong")
+    solver.suggestValue(xm, 60)
+    solver.updateVariables()
+
+    assert xm.value() == 60
+    assert x1.value() == 40
+    assert x2.value() == 80

--- a/recipes/matplotlib/meta.yaml
+++ b/recipes/matplotlib/meta.yaml
@@ -1,9 +1,16 @@
+# This recipe doesn't work on Python 3.9 (due to setuptools_scm issues),
+# or on Python 3.8 (due to numpy availability issues)
 package:
   name: matplotlib
   version: 3.6.0
 
 patches:
   - setupext.patch
+{% if py_version < (3, 11) %}
+  # This is required because of the inconsistency in old Apple Support versions
+  # in the error raised when subprocess is used.
+  - subprocess.patch
+{% endif %}
 
 requirements:
   host:
@@ -14,6 +21,3 @@ requirements:
   build:
     - certifi
     - setuptools_scm
-
-# about:
-#   license_file: LICENSE/LICENSE

--- a/recipes/matplotlib/meta.yaml
+++ b/recipes/matplotlib/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: matplotlib
+  version: 3.6.0
+
+patches:
+  - setupext.patch
+
+requirements:
+  host:
+    - freetype 2.9.1
+    - libpng 1.6.34
+    - numpy 1.26.0
+
+  build:
+    - certifi
+    - setuptools_scm
+
+# about:
+#   license_file: LICENSE/LICENSE

--- a/recipes/matplotlib/patches/setupext.patch
+++ b/recipes/matplotlib/patches/setupext.patch
@@ -1,0 +1,47 @@
+diff -ru matplotlib-3.6.0-orig/setupext.py matplotlib-3.6.0/setupext.py
+--- matplotlib-3.6.0-orig/setupext.py	2022-09-16 07:26:26.000000000 +0800
++++ matplotlib-3.6.0/setupext.py	2022-09-28 13:41:58.000000000 +0800
+@@ -199,7 +199,7 @@
+     'backend': config.get('rc_options', 'backend', fallback=None),
+     'system_freetype': config.getboolean(
+         'libs', 'system_freetype',
+-        fallback=sys.platform.startswith(('aix', 'os400'))
++        fallback=sys.platform.startswith(('aix', 'os400', 'ios', 'tvos', 'watchos'))
+     ),
+     'system_qhull': config.getboolean(
+         'libs', 'system_qhull', fallback=sys.platform.startswith('os400')
+@@ -493,8 +493,8 @@
+
+
+ def add_numpy_flags(ext):
+-    import numpy as np
+-    ext.include_dirs.append(np.get_include())
++    import site
++    ext.include_dirs.append(os.path.abspath(os.path.join(site.getsitepackages()[0], "numpy/core/include")))
+     ext.define_macros.extend([
+         # Ensure that PY_ARRAY_UNIQUE_SYMBOL is uniquely defined for each
+         # extension.
+@@ -563,14 +563,15 @@
+         # appropriate error message if the header indicates a too-old version.
+         ext.sources.insert(0, 'src/checkdep_freetype2.c')
+         if options.get('system_freetype'):
+-            pkg_config_setup_extension(
+-                # FreeType 2.3 has libtool version 9.11.3 as can be checked
+-                # from the tarball.  For FreeType>=2.4, there is a conversion
+-                # table in docs/VERSIONS.txt in the FreeType source tree.
+-                ext, 'freetype2',
+-                atleast_version='9.11.3',
+-                alt_exec=['freetype-config'],
+-                default_libraries=['freetype'])
++            # pkg_config_setup_extension(
++            #     # FreeType 2.3 has libtool version 9.11.3 as can be checked
++            #     # from the tarball.  For FreeType>=2.4, there is a conversion
++            #     # table in docs/VERSIONS.txt in the FreeType source tree.
++            #     ext, 'freetype2',
++            #     atleast_version='9.11.3',
++            #     alt_exec=['freetype-config'],
++            #     default_libraries=['freetype'])
++            ext.libraries.append("freetype")
+             ext.define_macros.append(('FREETYPE_BUILD_TYPE', 'system'))
+         else:
+             src_path = Path('build', f'freetype-{LOCAL_FREETYPE_VERSION}')

--- a/recipes/matplotlib/patches/subprocess.patch
+++ b/recipes/matplotlib/patches/subprocess.patch
@@ -1,0 +1,11 @@
+diff -ru matplotlib-3.6.0-orig/lib/matplotlib/font_manager.py matplotlib-3.6.0/lib/matplotlib/font_manager.py
+--- matplotlib-3.6.0-orig/lib/matplotlib/font_manager.py	2022-08-20 15:24:30
++++ matplotlib-3.6.0/lib/matplotlib/font_manager.py	2023-11-17 06:07:05
+@@ -332,7 +332,7 @@
+                 'Matplotlib needs fontconfig>=2.7 to query system fonts.')
+             return []
+         out = subprocess.check_output(['fc-list', '--format=%{file}\\n'])
+-    except (OSError, subprocess.CalledProcessError):
++    except (OSError, subprocess.CalledProcessError, RuntimeError):
+         return []
+     return [Path(os.fsdecode(fname)) for fname in out.split(b'\n')]

--- a/recipes/matplotlib/test_matplotlib.py
+++ b/recipes/matplotlib/test_matplotlib.py
@@ -1,0 +1,21 @@
+def test_png(self):
+    import io
+
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    plt.plot([1, 2])
+    bio = io.BytesIO()
+    plt.savefig(bio, format="png")
+    b = bio.getvalue()
+
+    EXPECTED_LEN = 16782
+    assert len(b) > int(EXPECTED_LEN * 0.8)
+    assert len(b) < int(EXPECTED_LEN * 1.2)
+
+    assert b[:24] == (
+        b"\x89PNG\r\n\x1a\n"
+        + b"\x00\x00\x00\rIHDR"  # File header
+        + b"\x00\x00\x02\x80"  # Header chunk header
+        + b"\x00\x00\x01\xe0"  # Width 640  # Height 480
+    )

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -471,14 +471,14 @@ class PythonPackageBuilder(Builder):
                 # Install the build requirements in the cross environment
                 self.cross_venv.pip_install(
                     self.log_file,
-                    ["build"] + pyproject["build-system"]["requires"],
+                    ["build", "wheel"] + pyproject["build-system"]["requires"],
                     wheels_path=Path.cwd() / "dist",
                 )
 
                 # Install the build requirements in the build environment
                 self.cross_venv.pip_install(
                     self.log_file,
-                    ["build"] + pyproject["build-system"]["requires"],
+                    ["build", "wheel"] + pyproject["build-system"]["requires"],
                     wheels_path=Path.cwd() / "dist",
                     build=True,
                 )

--- a/src/forge/package.py
+++ b/src/forge/package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from copy import deepcopy
 from pathlib import Path
 
@@ -71,7 +72,8 @@ class Package:
         meta_str = jinja2.Template(meta_template).render(
             version=tuple(int(v) for v in override_version.split("."))
             if override_version
-            else None
+            else None,
+            py_version=sys.version_info,
         )
 
         # Parse the rendered meta template


### PR DESCRIPTION
Adds recipe for matplotlib 3.6.0. 

Doesn't work on Python 3.9 due to setuptools_scm issue (it build, but tags the release as v0.0.0)
Doesn't work on Python 3.8 due to numpy availability.

Also adds kiwisolvers and contourpy as dependencies.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
