### PR TITLE
Improve error handling when setting up build environments

### DIFF
--- a/make_dep_wheels.py
+++ b/make_dep_wheels.py
@@ -6,6 +6,7 @@ that can be referenced during forge builds.
 You should not need to invoke this script directly; it should be called by `./setup-
 iOS.sh` when creating a new forge environment.
 """
+
 import os
 import re
 import shutil
@@ -44,6 +45,13 @@ def make_wheel(package, os_name, target):
 
     wheel_tag = f"py3-none-{os_name}_{min_version}_{target}".lower().replace(".", "_")
 
+    wheel_file = (
+        Path("dist") / f"{package.lower()}-{package_version_build}-{wheel_tag}.whl"
+    )
+    if wheel_file.exists():
+        print(f"{wheel_file} already exists")
+        return
+
     install_path = (
         support
         / "install"
@@ -51,12 +59,11 @@ def make_wheel(package, os_name, target):
         / target
         / f"{package.lower()}-{package_version_build}"
     )
-
-    if (
-        Path("dist") / f"{package.lower()}-{package_version_build}-{wheel_tag}.whl"
-    ).exists():
-        # Wheel already exists.
-        return
+    if not install_path.exists():
+        print(
+            f"Cannot build {target} wheel for {package}; can't find installed version in {install_path}"
+        )
+        sys.exit(1)
 
     with tempfile.TemporaryDirectory(dir=".") as tmp:
         wheel_path = Path(tmp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dependencies = [
     "Jinja2 == 3.1.3",
     "jsonschema == 4.21.1",
     "packaging == 24.0",
-    "tomli >= 2.0,< 3.0; python_version <= '3.10'",
     "PyYAML == 6.0.1",
+    "tomli >= 2.0,< 3.0; python_version <= '3.10'",
+    "wheel==0.43.0",
 ]
 
 [project.optional-dependencies]

--- a/setup-iOS.sh
+++ b/setup-iOS.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # set -e
 
 if [ -z "$1" ]; then
@@ -76,6 +75,9 @@ if [ ! -d ./venv$PYTHON_VER ]; then
 
     echo "Building platform dependency wheels..."
     python -m make_dep_wheels iOS
+    if [ $? -ne 0 ]; then
+        return
+    fi
 
     echo "Python $PYTHON_VERSION environment has been created."
     echo

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -237,18 +237,19 @@ class Builder(ABC):
         env.update(kwargs)
 
         # Add in some user environment keys that are useful
-        env.update(
-            {
-                key: os.environ.get(key)
-                for key in [
-                    "TMPDIR",
-                    "USER",
-                    "HOME",
-                    "LANG",
-                    "TERM",
-                ]
-            }
-        )
+        for key in [
+            "TMPDIR",
+            "USER",
+            "HOME",
+            "LANG",
+            "TERM",
+        ]:
+            try:
+                env[key] = os.environ[key]
+            except KeyError:
+                # User's environment doesn't provide the key.
+                pass
+
         return env
 
     def build(self, clean):


### PR DESCRIPTION
Two changes to improve error handling when setting up a build environment:

1. If the user's environment doesn't define `TMPDIR`, `USER`, `HOME`, `LANG`, or `TERM`, the compile environment doesn't attempt to pass in a `None` value.
2. If the required files can't be found to build wheel dependencies, an error is raised and the environment build process stops.

Fixes #35, #36

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
