### PR TITLE
Bump versions of support packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,10 @@ jobs:
       run: |
         source ./setup-iOS.sh $(cut -d- -f1 <<< ${{ matrix.python-version }})
         forge iOS lru-dict
+
+    # Build an example of a simple Python package using C++
+    # Calling setup script activates existing environment
+    - name: Build brotli
+      run: |
+        source ./setup-iOS.sh $(cut -d- -f1 <<< ${{ matrix.python-version }})
+        forge iOS brotli

--- a/recipes/brotli/meta.yaml
+++ b/recipes/brotli/meta.yaml
@@ -1,3 +1,3 @@
 package:
   name: Brotli
-  version: 1.0.9
+  version: 1.1.0

--- a/recipes/brotli/meta.yaml
+++ b/recipes/brotli/meta.yaml
@@ -1,8 +1,3 @@
 package:
   name: Brotli
   version: 1.0.9
-
-build:
-  # This is only needed because CXX is configured to be `clang`, not `clang++`
-  script_env:
-    - LDFLAGS=-lstdc++

--- a/recipes/pandas/meta.yaml
+++ b/recipes/pandas/meta.yaml
@@ -1,8 +1,3 @@
 package:
   name: pandas
   version: 1.5.3
-
-build:
-  # This is only needed because CXX is configured to be `clang`, not `clang++`
-  script_env:
-    - LDFLAGS=-lstdc++

--- a/setup-iOS.sh
+++ b/setup-iOS.sh
@@ -46,11 +46,11 @@ if [ -z "$PYTHON_APPLE_SUPPORT" ]; then
     if [ ! -d "$MOBILE_FORGE_SUPPORT_PATH/$PYTHON_VER/iOS" ]; then
         if [ -z "$2" ]; then
             case $PYTHON_VER in
-                3.9)  SUPPORT_REVISION=13 ;;
-                3.10) SUPPORT_REVISION=9 ;;
-                3.11) SUPPORT_REVISION=4 ;;
-                3.12) SUPPORT_REVISION=3 ;;
-                3.13) SUPPORT_REVISION=0 ;;
+                3.9)  SUPPORT_REVISION=14 ;;
+                3.10) SUPPORT_REVISION=10 ;;
+                3.11) SUPPORT_REVISION=5 ;;
+                3.12) SUPPORT_REVISION=4 ;;
+                3.13) SUPPORT_REVISION=1 ;;
                 *)
                     echo "No default support revision for $PYTHON_VER is known; it must be specified manually"
                     return


### PR DESCRIPTION
All the support packages have had an update; update mobile-forge to use those packages.

This update includes the addition of C++ shims, so manual configuration of `-lstdc++` is no longer required. A CI validation of this configuration (via Brotli) has been added. This necessitates updating the Brotli recipe version to avoid a build warning

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
