### PR TITLE
Use a generic 'cross' directory for cross environments.

### DIFF
--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -324,7 +324,7 @@ class CrossVEnv:
             [
                 str(self.host_python_home / "bin"),
                 str(self.venv_path / "bin"),
-                str(self.venv_path / self.venv_path.name / "bin"),
+                str(self.venv_path / "cross" / "bin"),
                 str(Path.home() / ".cargo/bin"),
                 "/usr/bin",
                 "/bin",
@@ -335,7 +335,7 @@ class CrossVEnv:
         )
 
         # Set VIRTUALENV to the active venv
-        env["VIRTUAL_ENV"] = str(self.venv_path / self.venv_path.name)
+        env["VIRTUAL_ENV"] = str(self.venv_path / "cross")
 
         # Remove PYTHONHOME if it's set
         try:


### PR DESCRIPTION
A small change to how virtual environments are named following a review of the PR to crossenv.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
