### PR TITLE
Ensure that pip is updated when a crossenv is created.

### DIFF
--- a/recipes/ninja/meta.yaml
+++ b/recipes/ninja/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ninja
-  version: 1.11.1
+  version: 1.11.1.1
 
 build:
   number: 1

--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -251,7 +251,37 @@ class CrossVEnv:
         self.verify()
         print("done.")
         print()
-        print(f"Cross platform-environment {self} created.")
+        print(f"Cross platform environment {self} created.")
+
+        print()
+        print("Updating cross-pip...")
+        self.run(
+            None,
+            [
+                "cross-python",
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--upgrade",
+                "pip",
+            ],
+        )
+
+        print()
+        print("Updating build-pip...")
+        self.run(
+            None,
+            [
+                "build-python",
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--upgrade",
+                "pip",
+            ],
+        )
 
     def verify(self):
         # python returns the cross-platform host tag.


### PR DESCRIPTION
When pip has been upgraded to add support for iOS, we'll need to ensure that pip has been upgraded in cross environments, rather than just using the platform default pip.

Also updates the version number for ninja; we were already downloading the 1.11.1.1 tarball, but we were tagging it wrong.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
