### PR TITLE
Update recipe for Pillow 11.0.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        runs-on: [ "macos-latest", "macos-12" ]
+        runs-on: [ "macos-latest" ]
 
         exclude:
           # Don't need to run x86 tests on every Python version
-          - python-version: "3.9"
-            runs-on: "macos-12"
-          - python-version: "3.10"
-            runs-on: "macos-12"
-          - python-version: "3.11"
-            runs-on: "macos-12"
           - python-version: "3.13"
-            runs-on: "macos-12"
+            runs-on: "macos-13"
 
     steps:
     - name: Checkout
@@ -53,8 +47,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5.2.0
       with:
-        # -dev suffix is a no-op for published releases
-        python-version: ${{ matrix.python-version }}-dev
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     # Initial call to the setup script sets up the environment
     - name: Set up Forge

--- a/recipes/pillow/meta.yaml
+++ b/recipes/pillow/meta.yaml
@@ -1,10 +1,13 @@
 package:
   name: Pillow
-  version: 10.4.0
+  version: 11.0.0
 
 {% if version and version <= (9, 4, 0) %}
 patches:
   - setup-9.4.0.patch
+{% elif version and version <= (10, 4, 0) %}
+patches:
+  - setup-10.4.0.patch
 {% else %}
 patches:
   - setup.patch

--- a/recipes/pillow/patches/setup-10.4.0.patch
+++ b/recipes/pillow/patches/setup-10.4.0.patch
@@ -1,12 +1,16 @@
-diff -ur pillow-11.0.0-orig/setup.py pillow-11.0.0/setup.py
---- pillow-11.0.0-orig/setup.py	2024-10-15 13:58:32
-+++ pillow-11.0.0/setup.py	2024-10-17 06:56:00
-@@ -445,10 +445,22 @@
+Common subdirectories: pillow-10.4.0-orig/Tests and pillow-10.4.0/Tests
+Common subdirectories: pillow-10.4.0-orig/_custom_build and pillow-10.4.0/_custom_build
+Common subdirectories: pillow-10.4.0-orig/depends and pillow-10.4.0/depends
+Common subdirectories: pillow-10.4.0-orig/docs and pillow-10.4.0/docs
+diff -u pillow-10.4.0-orig/setup.py pillow-10.4.0/setup.py
+--- pillow-10.4.0-orig/setup.py	2024-06-30 23:02:01
++++ pillow-10.4.0/setup.py	2024-09-25 11:15:21
+@@ -422,10 +422,22 @@
                  self.extensions.remove(extension)
                  break
 
--    def get_macos_sdk_path(self) -> str | None:
-+    def get_apple_sdk_path(self) -> str | None:
+-    def get_macos_sdk_path(self):
++    def get_apple_sdk_path(self):
          try:
 +            sdk = {
 +                ("ios", False): ["--sdk", "iphoneos"],
@@ -26,7 +30,7 @@ diff -ur pillow-11.0.0-orig/setup.py pillow-11.0.0/setup.py
                  .strip()
                  .decode("latin1")
              )
-@@ -606,13 +618,18 @@
+@@ -580,13 +592,18 @@
                  _add_directory(library_dirs, "/usr/X11/lib")
                  _add_directory(include_dirs, "/usr/X11/include")
 
@@ -46,7 +50,7 @@ diff -ur pillow-11.0.0-orig/setup.py pillow-11.0.0/setup.py
          elif (
              sys.platform.startswith("linux")
              or sys.platform.startswith("gnu")
-@@ -644,7 +661,10 @@
+@@ -618,7 +635,10 @@
          # FIXME: check /opt/stuff directories here?
 
          # standard locations
@@ -57,3 +61,6 @@ diff -ur pillow-11.0.0-orig/setup.py pillow-11.0.0/setup.py
 +        ):
              _add_directory(library_dirs, "/usr/local/lib")
              _add_directory(include_dirs, "/usr/local/include")
+
+Common subdirectories: pillow-10.4.0-orig/src and pillow-10.4.0/src
+Common subdirectories: pillow-10.4.0-orig/winbuild and pillow-10.4.0/winbuild

--- a/setup-iOS.sh
+++ b/setup-iOS.sh
@@ -64,8 +64,8 @@ if [ -z "$PYTHON_APPLE_SUPPORT" ]; then
                 3.9)  SUPPORT_REVISION=14 ;;
                 3.10) SUPPORT_REVISION=10 ;;
                 3.11) SUPPORT_REVISION=5 ;;
-                3.12) SUPPORT_REVISION=4 ;;
-                3.13) SUPPORT_REVISION=1 ;;
+                3.12) SUPPORT_REVISION=5 ;;
+                3.13) SUPPORT_REVISION=2 ;;
                 *)
                     echo "No default support revision for $PYTHON_VER is known; it must be specified manually"
                     return


### PR DESCRIPTION
Minor patch update needed for Pillow 11.0.0.

Takes the opportunity to update the support package version for 3.12 and 3.13, and update CI to remove the use of macOS-12 runners.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
