### PR TITLE
Add recipe for coverage.

### DIFF
--- a/recipes/coverage/meta.yaml
+++ b/recipes/coverage/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: coverage
+  version: 7.6.10


### PR DESCRIPTION
With beeware/briefcase#2101, Briefcase can only install binary wheels into iOS apps. Coverage is published as binary wheels for all desktop platforms, plus a source tarball - as a result, it can no longer be installed into Toga apps.

This adds a recipe to build binaries for coverage. They have been validated using [Toga's testbed](https://github.com/beeware/toga/actions/runs/12642877317/job/35230251758?pr=2978)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
