### PR TITLE
Bump flake8 from 7.2.0 to 7.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 7.2.0 to 7.3.0 and ran the update against the repo.