### PR TITLE
Bump shellcheck-py from v0.10.0.1 to v0.11.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/PyCQA/isort


### PR DESCRIPTION
Bumps `pre-commit` hook for `shellcheck-py` from v0.10.0.1 to v0.11.0.1 and ran the update against the repo.