### PR TITLE
Pin some environment dependencies.

### DIFF
--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -255,6 +255,9 @@ class CrossVEnv:
 
         print()
         print("Updating cross-pip...")
+        # Pip is pinned to 24.3.1, the last release in 2024. This project is
+        # entirely to support historical builds, on historical Python versions;
+        # as such, we're isolating ourself from drift in tools over time.
         self.run(
             None,
             [
@@ -264,7 +267,7 @@ class CrossVEnv:
                 "install",
                 "--disable-pip-version-check",
                 "--upgrade",
-                "pip",
+                "pip==24.3.1",
             ],
         )
 
@@ -279,7 +282,7 @@ class CrossVEnv:
                 "install",
                 "--disable-pip-version-check",
                 "--upgrade",
-                "pip",
+                "pip==24.3.1",
             ],
         )
 


### PR DESCRIPTION
pip 25.2 introduced some changes to pip behavior that broke builds.

As a preventative measure, pin some of the key build tools (pip, wheels, setuptools, build) to the last release from 2024. This should help ensure long-term maintainability of the historical builds required by this project.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
