### PR TITLE
Move pre-commit to multi-ecosystem group.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,5 @@ updates:
 
   - package-ecosystem: "pre-commit"
     directory: "/"
-    schedule:
-      # Check for updates on the first Sunday of every month, 8PM UTC
-      interval: "cron"
-      cronjob: "0 20 * * sun#1"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"


### PR DESCRIPTION
Move dependabot pre-commit configuration into the multi-ecosystem group.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
